### PR TITLE
Add example docker compose file for easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ A digital asset management system built with Flask and S3-compatible storage.
   </p>
 </details>
 
+## Installation
+
+You can use [this docker compose file](docker-compose.yml) to install this project using docker.
+
+Make sure to uncomment your desired storage backend.
+
 ## Container Registry
 
 This project includes automated container builds using Forgejo CI/CD. The container images are published to the project's container registry.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ A digital asset management system built with Flask and S3-compatible storage.
 
 You can use [this docker compose file](docker-compose.yml) to install this project using docker.
 
-Make sure to uncomment your desired storage backend.
-
 ## Container Registry
 
 This project includes automated container builds using Forgejo CI/CD. The container images are published to the project's container registry.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,6 @@ services:
     ## Database Configuration
     #  - DATABASE_URL=sqlite:///instance/app.db
 
-    ## File Storage
-    #  - STORAGE_URL=file://static/uploads
-
     ## S3 Storage Back-end
     #  - STORAGE_URL=s3://bucketname
     #  - S3_ACCESS_KEY=some-secure-user-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  pdam:
+    image: git.hack13.dev/hack13/personal-digital-asset-manager:latest
+    restart: unless-stopped
+    volumes:
+      - ./uploads:/app/static/uploads # Not required for S3 Storage Back-end
+      - ./app.db:/app/instance/app.db
+    environment:
+    ## Database Configuration
+    #  - DATABASE_URL=sqlite:///instance/app.db
+
+    ## File Storage
+    #  - STORAGE_URL=file://static/uploads
+
+    ## S3 Storage Back-end
+    #  - STORAGE_URL=s3://bucketname
+    #  - S3_ACCESS_KEY=some-secure-user-key
+    #  - S3_SECRET_KEY=some-secure-secret-key
+    #  - S3_ENDPOINT_URL=http://localhost:9000  # Optional, for S3-compatible services
+    #  - S3_PUBLIC_URL=http://your-public-url   # Optional, for direct file access
+    ports:
+      - 5000:5000


### PR DESCRIPTION
To make deployment of PDAM easier, I added an example docker compose file, which can be edited in the future if environment variables are being added.